### PR TITLE
Add HCT (Hue, Color, Space) color space. Fixes #2

### DIFF
--- a/src/components/mapart/json/colourMethods.json
+++ b/src/components/mapart/json/colourMethods.json
@@ -22,5 +22,9 @@
   "Ciede2000_Lab50": {
     "uniqueId": 5,
     "name": "CIEDE2000 D50 (L*a*b* space)"
+  },
+  "Hct": {
+    "uniqueId": 6,
+    "name": "HCT (Hue, Chroma, Tone)"
   }
 }


### PR DESCRIPTION
Implements HCT color space, which is a variant by Google using Hue and Chroma from CAM16 and Tone (L*) from CIELAB D65 color space.

Google's repository was used as a base:
https://github.com/material-foundation/material-color-utilities/blob/f9c29216244a1cacbc9825336aab2a3467f990a8/typescript/hct/hct.ts

The original code allowed changing many variables (see ViewingConditions), but those were all inlined in this implementation.

The color difference is calculated by a simple Euclidian difference in L* a* b* space.

This was a request in #2 